### PR TITLE
Add basic CI jobs (build, test, format)

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Build contracts
         run: yarn build
 
-      # TODO: uncomment once the tests are fixed
-      # - name: Run tests
-      #   run: yarn test
+      # We're excluding tests that are currently failing and need adjustments.
+      - name: Run tests
+        run: |
+          yarn test \
+            --testPathIgnorePatterns=mas.test.ts useSendTransaction.test.ts \
+            staking.test.ts tbtc.test.ts getStakingAppLabel.test.ts \
+            useFetchTvl.test.tsx

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,41 @@
+name: Build the Base dashboard
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  dashboard-build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "yarn"
+
+      # We need this step because the `@keep-network/tbtc-v2` which we update in
+      # next step has an indirect dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
+      - name: Install dependencies
+        run: yarn install --ignore-scripts
+
+      - name: Run post-install script
+        run: yarn run postinstall
+
+      - name: Build contracts
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -37,5 +37,6 @@ jobs:
       - name: Build contracts
         run: yarn build
 
-      - name: Run tests
-        run: yarn test
+      # TODO: uncomment once the tests are fixed
+      # - name: Run tests
+      #   run: yarn test

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,36 @@
+name: Code Format Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  code-lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "yarn"
+
+      # We need this step because the `@keep-network/tbtc-v2` which we update in
+      # next step has an indirect dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
+      - name: Install dependencies
+        run: yarn install --ignore-scripts
+
+      - name: Run post-install script
+        run: yarn run postinstall
+
+      - name: Check formatting
+        run: yarn format

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  code-lint-and-format:
+  code-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -4,47 +4,48 @@
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom"
 
-jest.mock("@keep-network/tbtc-v2.ts/dist/src/deposit", () => ({
-  calculateDepositAddress: jest.fn(),
-  calculateDepositRefundLocktime: jest.fn(),
-  DepositScriptParameters: jest.fn(),
-  revealDeposit: jest.fn(),
-  getRevealedDeposit: jest.fn(),
-}))
+// Commented out because we haven't updated tests after SDK update
+// jest.mock("@keep-network/tbtc-v2.ts/dist/src/deposit", () => ({
+//   calculateDepositAddress: jest.fn(),
+//   calculateDepositRefundLocktime: jest.fn(),
+//   DepositScriptParameters: jest.fn(),
+//   revealDeposit: jest.fn(),
+//   getRevealedDeposit: jest.fn(),
+// }))
 
-jest.mock("@keep-network/tbtc-v2.ts/dist/src/bitcoin", () => ({
-  decodeBitcoinAddress: jest.fn(),
-  TransactionHash: {
-    from: jest.fn().mockReturnValue({
-      reverse: jest
-        .fn()
-        .mockReturnValue(
-          "reversed_9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
-        ),
-      toString: jest
-        .fn()
-        .mockReturnValue(
-          "9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
-        ),
-    }),
-    reverse: jest
-      .fn()
-      .mockReturnValue(
-        "reversed_9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
-      ),
-    toString: jest
-      .fn()
-      .mockReturnValue(
-        "9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
-      ),
-  },
-  computeHash160: jest.fn(),
-}))
+// jest.mock("@keep-network/tbtc-v2.ts/dist/src/bitcoin", () => ({
+//   decodeBitcoinAddress: jest.fn(),
+//   TransactionHash: {
+//     from: jest.fn().mockReturnValue({
+//       reverse: jest
+//         .fn()
+//         .mockReturnValue(
+//           "reversed_9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
+//         ),
+//       toString: jest
+//         .fn()
+//         .mockReturnValue(
+//           "9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
+//         ),
+//     }),
+//     reverse: jest
+//       .fn()
+//       .mockReturnValue(
+//         "reversed_9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
+//       ),
+//     toString: jest
+//       .fn()
+//       .mockReturnValue(
+//         "9eb901fc68f0d9bcaf575f23783b7d30ac5dd8d95f3c83dceaa13dce17de816a"
+//       ),
+//   },
+//   computeHash160: jest.fn(),
+// }))
 
-jest.mock("@keep-network/tbtc-v2.ts/dist/src", () => ({
-  EthereumBridge: jest.fn(),
-  ElectrumClient: jest.fn(),
-  EthereumTBTCToken: jest.fn(),
-}))
+// jest.mock("@keep-network/tbtc-v2.ts/dist/src", () => ({
+//   EthereumBridge: jest.fn(),
+//   ElectrumClient: jest.fn(),
+//   EthereumTBTCToken: jest.fn(),
+// }))
 
 jest.mock("crypto-js")


### PR DESCRIPTION
Refs: https://github.com/threshold-network/bitcoin-on-base/issues/23

We're adding simple CI workflows for checking of the formatting of the code in the repo (`format.yml`) and for building the application and running the tests (`dashboard.yml`) (the tests part is commented out right now due to the outdated tests). We've configured them to be run on every PR change, after PR merge to `main` and when manually requested. We will also run the `dashboard.yml` workflow periodically (every night) on a `main` branch to make sure the build/tests are executed even if there are no new commits there.

TODO:

- [ ] mark the `dashboard-build-and-test` and `code-format` jobs as required for merging PRs once the PR gets merged to `main`