### PR TITLE
Add a CI job deploying Bitcoin on Base on testnets

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -44,3 +44,78 @@ jobs:
             --testPathIgnorePatterns=mas.test.ts useSendTransaction.test.ts \
             staking.test.ts tbtc.test.ts getStakingAppLabel.test.ts \
             useFetchTvl.test.tsx
+
+  build-and-deploy:
+    needs: dashboard-build-and-test
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "yarn"
+
+      # We need this step because the `@keep-network/tbtc-v2` which we update in
+      # next step has an indirect dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
+      - name: Install dependencies
+        run: yarn install --ignore-scripts
+
+      - name: Run post-install script
+        run: yarn run postinstall
+
+      - name: Build contracts
+        run: yarn build
+
+        # Using fake ternary expression to decide which testnet to use,
+        # depending on a trigger.
+      - name: Load environment variables
+        uses: keep-network/ci/actions/load-env-variables@v2
+        with:
+          environment: |
+            ${{ github.event_name }} == 'push'
+              && 'sepolia'
+              || 'goerli'
+
+      - name: Build
+        run: yarn build
+        env:
+          PUBLIC_URL: /
+          ETH_HOSTNAME_HTTP: |
+            ${{ github.event_name == 'push'
+              && secrets.SEPOLIA_ETH_HOSTNAME_HTTP
+              || secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ETH_HOSTNAME_WS: |
+            ${{ github.event_name == 'push'
+              && secrets.SEPOLIA_ETH_HOSTNAME_WS
+              || secrets.GOERLI_ETH_HOSTNAME_WS }}
+          NODE_OPTIONS: --max_old_space_size=4096
+          ELECTRUM_PROTOCOL: ${{ secrets.TESTNET_ELECTRUMX_PROTOCOL }}
+          ELECTRUM_HOST: ${{ secrets.TESTNET_ELECTRUMX_HOST }}
+          ELECTRUM_PORT: ${{ secrets.TESTNET_ELECTRUMX_PORT }}
+          SENTRY_SUPPORT: true
+          SENTRY_DSN: ${{ secrets.TESTNET_SENTRY_DSN }}
+          WALLET_CONNECT_PROJECT_ID: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
+
+      - name: Deploy to GCP
+        if: github.event_name == 'push'
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        with:
+          service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          project: ${{ env.GOOGLE_PROJECT_ID }}
+          bucket-name: |
+            ${{ github.event_name == 'push' }}
+              && 'bob.test.threshold.network'
+              || 'bob-goerli.test.threshold.network'
+          bucket-path: ${{ github.head_ref }}
+          build-folder: build
+          set-website: ${{ inputs.preview == false }}
+          home-page-path: index.html
+          error-page-path: index.html


### PR DESCRIPTION
As Wormhole does not support yet the Base Sepolia testnet we want to have a way of deploying the project on Goerli / Base Goerli when needed. The Goerli testnet was supposed to get deprecated with the end of 2023, but it looks it is still in pretty good shape and has many active validators (see https://goerli.beaconcha.in/). Also, according to https://goerli.basescan.org/, 'Base Goerli will be gradually deprecated starting mid-January and fully shut down by 9th Feb 2024.'. We hope that by that time Wormhole will start to support Base Sepolia and we'll be able to switch our config to run fully on Sepolia testnet. Until then all manual runs of the workflow will result with deploying using Goerli contracts and all pushes to main will result with deploys using Sepolia contracts (we may need to some mocking and accept that not everything will be working there).

Ref: https://github.com/threshold-network/bitcoin-on-base/pull/16

TODO:
Configure the following secrets:

- [ ] SEPOLIA_ETH_HOSTNAME_HTTP
- [ ] GOERLI_ETH_HOSTNAME_HTTP
- [ ] TESTNET_ELECTRUMX_PROTOCOL
- [ ] ESTNET_ELECTRUMX_HOST
- [ ] TESTNET_ELECTRUMX_PORT
- [ ] TESTNET_SENTRY_DSN
- [ ] WALLET_CONNECT_PROJECT_ID
- [ ] KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64
