### PR TITLE
Don't load Google Project ID using `load-env-variables` action

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -74,16 +74,6 @@ jobs:
       - name: Build contracts
         run: yarn build
 
-        # Using fake ternary expression to decide which testnet to use,
-        # depending on a trigger.
-      - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@v2
-        with:
-          environment: |
-            ${{ github.event_name }} == 'push'
-              && 'sepolia'
-              || 'goerli'
-
       - name: Build
         run: yarn build
         env:
@@ -109,7 +99,7 @@ jobs:
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          project: ${{ env.GOOGLE_PROJECT_ID }}
+          project: keep-test-f3e0
           bucket-name: |
             ${{ github.event_name == 'push' }}
               && 'bob.test.threshold.network'


### PR DESCRIPTION
The value of `project` key in the `Deploy to GCP` step is the same for both Sepolia and Goerli environments. We don't need to load it using `keep-network/ci/actions/load-env-variables` action. Besides, we had some misconfiguration in the previous config causing the action to not retrieve the expected data.

The syntax we used in the workflow was interpreted not the way we wanted. Changing to a different notation.