### PR TITLE
Parametrize `workflow_dispatch` to allow choosing `environment`

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -109,11 +109,7 @@ jobs:
 
       - name: Deploy to GCP
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        # We run the action in version from `alpine-version-413.0.0` branch,
-        # which contains a fix for the issue introduced in the `414.0.0` version
-        # of the `cloud-sdk` (`rsync` fails for users with no
-        # `storage.buckets.get` permission).
-        uses: thesis/gcp-storage-bucket-action@alpine-version-413.0.0
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: keep-test-f3e0

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: keep-test-f3e0
-          bucket-name: 'bob.test.threshold.network'
+          bucket-name: "bob.test.threshold.network"
           bucket-path: ${{ github.head_ref }}
           build-folder: build
           set-website: ${{ inputs.preview == false }}

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Build
         run: yarn build
         env:
+          # Temporarily we hardcode Goerli chain id (we'll need to change this
+          # to `11155111` when we switch our deployment to Sepolia.
+          CHAIN_ID: 5
           PUBLIC_URL: /
           ETH_HOSTNAME_HTTP: |
             ${{ github.event_name == 'push' 

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -109,7 +109,11 @@ jobs:
 
       - name: Deploy to GCP
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        # We run the action in version from `alpine-version-413.0.0` branch,
+        # which contains a fix for the issue introduced in the `414.0.0` version
+        # of the `cloud-sdk` (`rsync` fails for users with no
+        # `storage.buckets.get` permission).
+        uses: thesis/gcp-storage-bucket-action@alpine-version-413.0.0
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: keep-test-f3e0

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -8,6 +8,15 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment"
+        required: true
+        type: choice
+        options:
+          - sepolia
+          - goerli
+        default: sepolia
 
 jobs:
   dashboard-build-and-test:
@@ -79,11 +88,15 @@ jobs:
         env:
           PUBLIC_URL: /
           ETH_HOSTNAME_HTTP: |
-            ${{ github.event_name == 'push'
-              && secrets.SEPOLIA_ETH_HOSTNAME_HTTP
+            ${{ github.event_name == 'push' 
+              || (github.event_name == 'workflow_dispatch' 
+              && github.event.inputs.environment == 'sepolia')
+              && secrets.SEPOLIA_ETH_HOSTNAME_HTTP 
               || secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ETH_HOSTNAME_WS: |
             ${{ github.event_name == 'push'
+              || (github.event_name == 'workflow_dispatch' 
+              && github.event.inputs.environment == 'sepolia')
               && secrets.SEPOLIA_ETH_HOSTNAME_WS
               || secrets.GOERLI_ETH_HOSTNAME_WS }}
           NODE_OPTIONS: --max_old_space_size=4096
@@ -100,10 +113,7 @@ jobs:
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: keep-test-f3e0
-          bucket-name: |
-            ${{ github.event_name == 'push' }}
-              && 'bob.test.threshold.network'
-              || 'bob-goerli.test.threshold.network'
+          bucket-name: 'bob.test.threshold.network'
           bucket-path: ${{ github.head_ref }}
           build-folder: build
           set-website: ${{ inputs.preview == false }}

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -114,7 +114,6 @@ jobs:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           project: keep-test-f3e0
           bucket-name: "bob.test.threshold.network"
-          bucket-path: ${{ github.head_ref }}
           build-folder: build
           set-website: ${{ inputs.preview == false }}
           home-page-path: index.html

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -108,7 +108,7 @@ jobs:
           WALLET_CONNECT_PROJECT_ID: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
 
       - name: Deploy to GCP
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}


### PR DESCRIPTION
We want to be able to deploy the dashboard manually using both Sepolia and Goerli based configs.
We'll deploy using Sepolia config on pushes to `main` or when triggered manually with `sepolia` environment input.
We'll deploy using Goerli config when triggered manually with the `goerli` environment input.