### PR TITLE
Fix: Set dark mode as default

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -53,6 +53,10 @@ const index = extendTheme({
     Button,
     Alert,
   },
+  config: {
+    initialColorMode: "dark",
+    useSystemColorMode: false,
+  },
 })
 
 export default index


### PR DESCRIPTION
The application is meant to work in dark mode by default. This PR adjusts Chakra configuration to define dark mode as default.